### PR TITLE
Report correct source position for quasiquoted parsers (see #7)

### DIFF
--- a/main/Data/API/MigrationTool.hs
+++ b/main/Data/API/MigrationTool.hs
@@ -68,7 +68,7 @@ writeJsonFile :: JS.ToJSON a => FilePath -> a -> IO ()
 writeJsonFile file = BS.writeFile file . JS.encodePretty
 
 readApiFile :: FilePath -> IO APIWithChangelog
-readApiFile file = fmap parseAPIWithChangelog (readFile file)
+readApiFile file = fmap (parseAPIWithChangelog file (0,0)) (readFile file)
 
 data ChangeTag = None
     deriving (Read, Show)
@@ -94,4 +94,4 @@ reformatJSON file1 file2 = do
 parse :: FilePath -> IO ()
 parse file = do
   s <- readFile file
-  print (parseAPIWithChangelog s)
+  print (parseAPIWithChangelog file (0,0) s)


### PR DESCRIPTION
Error messages are still terrible, but at least the source position gives a clue.  This changes the types of `parseAPI` and `parseAPIWithChangelog`, but most users will be using the quasiquoters and so will be unaffected.
