### PR TITLE
Fixes for GHC 7.10

### DIFF
--- a/api-tools.cabal
+++ b/api-tools.cabal
@@ -27,6 +27,9 @@ Source-Repository this
   Location:          git://github.com/iconnect/api-tools.git
   Tag:               0.6
 
+flag time15
+  default: True
+
 Library
   Hs-Source-Dirs:    src
 
@@ -84,16 +87,22 @@ Library
         containers           >= 0.5      && < 0.6  ,
         deepseq              >= 1.1      && < 1.5  ,
         lens                 >= 3.8.7    && < 4.14 ,
-        old-locale           >= 1.0.0.4  && < 1.1  ,
         regex-compat-tdfa    >= 0.95.1   && < 0.96 ,
         safe                 >= 0.3.3    && < 0.4  ,
         safecopy             >= 0.8.1    && < 0.9  ,
         scientific           >= 0.3      && < 0.4  ,
-        time                 >= 1.4      && < 1.6  ,
         template-haskell     >= 2.7      && < 2.11 ,
         text                 >= 0.11.3   && < 1.3  ,
         unordered-containers >= 0.2.3.0  && < 0.3  ,
         vector               >= 0.10.0.1 && < 0.12
+
+  if flag(time15)
+    Build-depends:
+        time                 >= 1.5.0    && < 1.6
+  else
+    Build-depends:
+        old-locale           >= 1        && < 1.1,
+        time                 >= 1.1.4    && < 1.5
 
   Build-tools:
         alex,
@@ -124,11 +133,9 @@ Executable migration-tool
         case-insensitive     >= 1.0      && < 1.3  ,
         containers           >= 0.5      && < 0.6  ,
         lens                 >= 3.8.7    && < 4.14 ,
-        old-locale           >= 1.0.0.4  && < 1.1  ,
         regex-compat-tdfa    >= 0.95.1   && < 0.96 ,
         safe                 >= 0.3.3    && < 0.4  ,
         safecopy             >= 0.8.1    && < 0.9  ,
-        time                 >= 1.4      && < 1.6  ,
         template-haskell     >= 2.7      && < 2.11 ,
         text                 >= 0.11.3   && < 1.3  ,
         unordered-containers >= 0.2.3.0  && < 0.3  ,
@@ -170,14 +177,13 @@ Test-Suite test-api-tools
         case-insensitive     >= 1.0      && < 1.3  ,
         containers           >= 0.5      && < 0.6  ,
         lens                 >= 3.8.7    && < 4.14 ,
-        old-locale           >= 1.0.0.4  && < 1.1  ,
         regex-compat-tdfa    >= 0.95.1   && < 0.96 ,
         safe                 >= 0.3.3    && < 0.4  ,
         safecopy             >= 0.8.1    && < 0.9  ,
         tasty                >= 0.10.1   && < 0.12 ,
         tasty-hunit          >= 0.2      && < 10.0 ,
         tasty-quickcheck     >= 0.3      && < 0.9  ,
-        time                 >= 1.4      && < 1.6  ,
+        time,
         template-haskell     >= 2.7      && < 2.11 ,
         text                 >= 0.11.3   && < 1.3  ,
         unordered-containers >= 0.2.3.0  && < 0.3  ,

--- a/api-tools.cabal
+++ b/api-tools.cabal
@@ -71,10 +71,10 @@ Library
   Build-depends:
         Cabal                >= 1.4      && < 2    ,
         QuickCheck           >= 2.5.1    && < 2.9  ,
-        aeson                >= 0.6.2    && < 0.9  ,
+        aeson                >= 0.6.2    && < 0.11 ,
         aeson-pretty         >= 0.1      && < 0.8  ,
         array                >= 0.4      && < 0.6  ,
-        attoparsec           >= 0.10.4   && < 0.13 ,
+        attoparsec           >= 0.10.4   && < 0.14 ,
         base                 >= 4        && < 5    ,
         base16-bytestring    >= 0.1      && < 0.2  ,
         base64-bytestring    >= 1.0      && < 1.1  ,
@@ -93,7 +93,7 @@ Library
         template-haskell     >= 2.7      && < 2.11 ,
         text                 >= 0.11.3   && < 1.3  ,
         unordered-containers >= 0.2.3.0  && < 0.3  ,
-        vector               >= 0.10.0.1 && < 0.11
+        vector               >= 0.10.0.1 && < 0.12
 
   Build-tools:
         alex,
@@ -114,10 +114,10 @@ Executable migration-tool
   Build-depends:
         api-tools,
         QuickCheck           >= 2.5.1    && < 2.9  ,
-        aeson                >= 0.6.2    && < 0.9  ,
+        aeson                >= 0.6.2    && < 0.11 ,
         aeson-pretty         >= 0.1      && < 0.8  ,
         array                >= 0.4      && < 0.6  ,
-        attoparsec           >= 0.10.4   && < 0.13 ,
+        attoparsec           >= 0.10.4   && < 0.14 ,
         base                 >= 4        && < 5    ,
         base64-bytestring    >= 1.0      && < 1.1  ,
         bytestring           >= 0.9      && < 0.11 ,
@@ -132,7 +132,7 @@ Executable migration-tool
         template-haskell     >= 2.7      && < 2.11 ,
         text                 >= 0.11.3   && < 1.3  ,
         unordered-containers >= 0.2.3.0  && < 0.3  ,
-        vector               >= 0.10.0.1 && < 0.11
+        vector               >= 0.10.0.1 && < 0.12
 
   GHC-Options:
         -main-is Data.API.MigrationTool
@@ -160,10 +160,10 @@ Test-Suite test-api-tools
         api-tools,
         Cabal                >= 1.4      && < 2    ,
         QuickCheck           >= 2.5.1    && < 2.9  ,
-        aeson                >= 0.6.2    && < 0.9  ,
+        aeson                >= 0.6.2    && < 0.11 ,
         aeson-pretty         >= 0.1      && < 0.8  ,
         array                >= 0.4      && < 0.6  ,
-        attoparsec           >= 0.10.4   && < 0.13 ,
+        attoparsec           >= 0.10.4   && < 0.14 ,
         base                 >= 4        && < 5    ,
         base64-bytestring    >= 1.0      && < 1.1  ,
         bytestring           >= 0.9      && < 0.11 ,
@@ -174,14 +174,14 @@ Test-Suite test-api-tools
         regex-compat-tdfa    >= 0.95.1   && < 0.96 ,
         safe                 >= 0.3.3    && < 0.4  ,
         safecopy             >= 0.8.1    && < 0.9  ,
-        tasty                >= 0.10.1   && < 0.11 ,
+        tasty                >= 0.10.1   && < 0.12 ,
         tasty-hunit          >= 0.2      && < 10.0 ,
         tasty-quickcheck     >= 0.3      && < 0.9  ,
         time                 >= 1.4      && < 1.6  ,
         template-haskell     >= 2.7      && < 2.11 ,
         text                 >= 0.11.3   && < 1.3  ,
         unordered-containers >= 0.2.3.0  && < 0.3  ,
-        vector               >= 0.10.0.1 && < 0.11
+        vector               >= 0.10.0.1 && < 0.12
 
   GHC-Options:
         -main-is Data.API.Test.Main

--- a/src/Data/API/Tools/DeepSeq.hs
+++ b/src/Data/API/Tools/DeepSeq.hs
@@ -46,4 +46,6 @@ gen_su = mkTool $ \ ts (an, su) -> do
         f (fn,_) = match (nodeAltConP an fn [varP y]) (normalB [e|rnf $(varE y)|]) []
 
 gen_se :: Tool (APINode, SpecEnum)
-gen_se = mkTool $ \ ts (an, _) -> optionalInstanceD ts ''NFData [nodeRepT an] []
+gen_se = mkTool $ \ ts (an, _) ->
+    optionalInstanceD ts ''NFData [nodeRepT an]
+        [simpleD 'rnf [e| \ x -> seq x () |] ]

--- a/tests/Data/API/Test/Gen.hs
+++ b/tests/Data/API/Test/Gen.hs
@@ -26,6 +26,7 @@ $(generateAPITools DSL.example
                    , lensTool
                    , safeCopyTool
                    , exampleTool
+                   , deepSeqTool
                    , samplesTool   (mkName "exampleSamples")
                    , jsonTestsTool (mkName "exampleTestsJSON")
                    , cborTestsTool (mkName "exampleTestsCBOR")
@@ -120,6 +121,7 @@ $(generateAPIToolsWith (defaultToolSettings { newtypeSmartConstructors = True })
                    , lensTool
                    , safeCopyTool
                    , exampleTool
+                   , deepSeqTool
                    , samplesTool   (mkName "example2Samples")
                    , jsonTestsTool (mkName "example2TestsJSON")
                    , cborTestsTool (mkName "example2TestsCBOR")


### PR DESCRIPTION
This corrects the generated `DeepSeq` instances the quick way (fixes #43), and corrects the dependency bounds to make it easier to find a build plan.