### PR TITLE
Make it easier to copy incomplete changelog errors

### DIFF
--- a/src/Data/API/PP.hs
+++ b/src/Data/API/PP.hs
@@ -8,6 +8,7 @@ module Data.API.PP
     , indent
     ) where
 
+import           Data.API.Scan (keywords)
 import           Data.API.JSON
 import           Data.API.Types
 
@@ -55,7 +56,8 @@ instance PP TypeName where
   pp = _TypeName
 
 instance PP FieldName where
-  pp = _FieldName
+  pp (FieldName fn) | fn `elem` keywords = "'" ++ fn ++ "'"
+                    | otherwise          = fn
 
 instance PP APIType where
   pp (TyList  ty) = "[" ++ pp ty ++ "]"

--- a/src/Data/API/Scan.x
+++ b/src/Data/API/Scan.x
@@ -6,6 +6,7 @@ module Data.API.Scan
     , PToken
     , AlexPosn(..)
     , Token(..)
+    , keywords
     ) where
 
 import           Data.API.Types
@@ -41,8 +42,8 @@ tokens :-
     ">="                                { simple    GtEq            }
     "?"                                 { simple    Query           }
     ","                                 { simple    Comma           }
-    version                             { simple    Version         }
-    with                                { simple    With            }    
+    version                             { simple    Version         } -- N.B. extend the 'keywords list below
+    with                                { simple    With            } -- when adding new keywords!
     integer                             { simple    Integer         }
     boolean                             { simple    Boolean         }
     utc                                 { simple    UTC             }
@@ -78,6 +79,14 @@ tokens :-
     "(*"(\n|[^\*]|\*[^\)])*"*)"         { block_comment             }
 
 {
+
+keywords :: [String]
+keywords = [ "version", "with", "integer", "boolean", "utc", "string"
+           , "binary", "json", "record", "union", "enum", "basic", "changes"
+           , "added", "removed", "renamed", "changed", "default", "field"
+           , "alternative", "migration", "to", "nothing", "true", "false"
+           , "read-only"
+           ]
 
 type PToken = (AlexPosn,Token)
 


### PR DESCRIPTION
Fixes #40 and see #6. This prints the list of API differences in (reverse) dependency order, and quotes fields where necessary.