### PR TITLE
Add space between header and type name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/src/Data/API/Markdown.hs
+++ b/src/Data/API/Markdown.hs
@@ -3,7 +3,7 @@
 -- | This module generates Markdown-formatted documentation for an
 -- API, like this:
 --
--- > ###Foo
+-- > ### Foo
 -- >
 -- > a test defn
 -- >
@@ -65,7 +65,7 @@ node mdm an tl_md =
 
 header :: MarkdownMethods -> APINode -> MDComment -> MDComment
 header mdm an tl_md =
-                                printf "###%s\n\n%s\n\n%s" nm_md (mdmPp mdm cm_md "") tl_md
+                                printf "### %s\n\n%s\n\n%s" nm_md (mdmPp mdm cm_md "") tl_md
   where
     nm_md = type_name_md an
     cm_md = comment_md   an

--- a/stack-7.0.yaml
+++ b/stack-7.0.yaml
@@ -1,0 +1,15 @@
+resolver: lts-7.19
+system-ghc: false
+install-ghc: true
+flags:
+    binary-serialise-cbor:
+      newtime15: true
+packages:
+  - '.'
+  - location:
+      git: git@github.com:well-typed/binary-serialise-cbor.git
+      commit: 42af834eb84da3fbb7319a1f6480367ca99dcbfd
+
+extra-deps:
+  - binary-serialise-cbor-0.1.1.0
+  - aeson-pretty-0.7.2


### PR DESCRIPTION
Hey @adamgundry ! Do you think this will be enough to prevent GitHub from failing to parse api-tools-generated markdown documents?

An a bonus, I have added a barebone-but-working `stack-7.0.yml` and ignored `.stack-work` for guys (like me) using stack to build api-tools 😉  Hope you don't mind!