### PR TITLE
Silently truncate floating point numbers in JSON input

### DIFF
--- a/api-tools.cabal
+++ b/api-tools.cabal
@@ -1,5 +1,5 @@
 Name:                api-tools
-Version:             0.8.0.0
+Version:             0.8.0.1
 Synopsis:            DSL for generating API boilerplate and docs
 Description:         api-tools provides a compact DSL for describing an API.
                      It uses Template Haskell to generate the

--- a/changelog
+++ b/changelog
@@ -1,5 +1,8 @@
 -*-change-log-*-
 
+0.8.0.1 Adam Gundry <adam@well-typed.com> October 2017
+	* Silently truncate floating point numbers to integers
+
 0.8.0.0 Mikolaj Konarski <mikolaj@well-typed.com> August 2017
 	* Update to match the published cborg 0.1 API
 

--- a/tests/Data/API/Test/JSON.hs
+++ b/tests/Data/API/Test/JSON.hs
@@ -43,6 +43,8 @@ basicValueDecoding = sequence_ [ help (JS.String "12")  (12 :: Int) True
                                , help (JS.String "0")   (0 :: Int)  True
                                , help (JS.String "-9")  (-9 :: Int) True
                                , help (JS.String "1a")  (1 :: Int)  False
+                               , help (JS.Number 1.1)   (1 :: Int)  True
+                               , help (JS.Number 1.9)   (1 :: Int)  True
                                , help (JS.Number 0)     False       True
                                , help (JS.Number 1)     True        True
                                , help (JS.Number 2)     True        False


### PR DESCRIPTION
Fixes #62. This approximately restores the behaviour prior to `aeson-1.0.0.0`.