### PR TITLE
Add  traversalsTool

### DIFF
--- a/src/Data/API/Tools/Traversal.hs
+++ b/src/Data/API/Tools/Traversal.hs
@@ -4,6 +4,7 @@
 
 module Data.API.Tools.Traversal
     ( traversalTool
+    , traversalsTool
     ) where
 
 import           Data.API.NormalForm
@@ -37,7 +38,12 @@ import           Prelude
 -- defined manually in the same module as the call to 'traversalTool',
 -- otherwise the generated code will lead to scope errors.
 traversalTool :: TypeName -> TypeName -> APITool
-traversalTool root x = readTool (apiNodeTool . s)
+traversalTool root = traversalsTool [root]
+
+-- | Like 'traversalTool', but it allows passing a list of \"roots\", to avoid conflicting
+-- declarations.
+traversalsTool :: [TypeName] -> TypeName -> APITool
+traversalsTool root x = readTool (apiNodeTool . s)
   where
     s api = apiSpecTool mempty (simpleTool (uncurry $ traversalRecord napi targets x))
                                (simpleTool (uncurry $ traversalUnion  napi targets x)) mempty mempty
@@ -49,7 +55,7 @@ traversalTool root x = readTool (apiNodeTool . s)
         -- traversed type
         targets = (transitiveDeps        napi rootSet `Set.union` rootSet) `Set.intersection`
                   (transitiveReverseDeps napi xSet    `Set.union` xSet)
-        rootSet = Set.singleton root
+        rootSet = Set.fromList root
         xSet    = Set.singleton x
 
 


### PR DESCRIPTION
This patch adds a `traversalsTool` variant which allows writing something like:

```hs
$(generateAPITools atlasSchema
    (map (traversalsTool ["ARequest", "AResponse"]) [
        "Password"
      , "AuthorizationKey"
      , "OTPDeviceToken"
      , "LoginResponse"
      , "OAuth2AccessToken"
      , "OAuth2RefreshToken"
      , "MeetingPassword"
      , "ConferenceServerSecretKey"
      ]))
```

This allows generating all the traversals at once, avoiding conflicting declarations one would have trying to generate traversals for the same "sub" (from a different root).