### PR TITLE
Encode space leak fix

### DIFF
--- a/src/Data/API/Tools/Datatypes.hs
+++ b/src/Data/API/Tools/Datatypes.hs
@@ -8,6 +8,7 @@ module Data.API.Tools.Datatypes
     , nodeT
     , nodeRepT
     , nodeConE
+    , nodeConP
     , nodeNewtypeConE
     , nodeFieldE
     , nodeFieldP
@@ -239,9 +240,13 @@ nodeT = conT . type_nm
 nodeRepT :: APINode -> TypeQ
 nodeRepT = conT . rep_type_nm
 
--- | The constructor for a record API node
+-- | The constructor for a record API node, as an expression
 nodeConE :: APINode -> ExpQ
 nodeConE = conE . rep_type_nm
+
+-- | The constructor for a record API node, as a pattern
+nodeConP :: APINode -> [PatQ] -> PatQ
+nodeConP an = conP (rep_type_nm an)
 
 -- | The constructor for a newtype, which might be renamed
 nodeNewtypeConE :: ToolSettings -> APINode -> SpecNewtype -> ExpQ
@@ -263,6 +268,6 @@ nodeAltConE an fn = conE $ pref_con_nm an fn
 nodeAltConP :: APINode -> FieldName -> [PatQ] -> PatQ
 nodeAltConP an fn = conP (pref_con_nm an fn)
 
--- | The projection function from a newtype API node, as an epxression
+-- | The projection function from a newtype API node, as an expression
 newtypeProjectionE :: APINode -> ExpQ
 newtypeProjectionE = varE . newtype_prj_nm

--- a/src/Data/Binary/Serialise/CBOR/Extra.hs
+++ b/src/Data/Binary/Serialise/CBOR/Extra.hs
@@ -13,7 +13,6 @@ module Data.Binary.Serialise.CBOR.Extra
 
 import           Codec.Serialise.Decoding
 import           Codec.Serialise.Encoding
-import           Data.List (foldl1')
 import qualified Data.Text                      as T
 
 #if MIN_VERSION_base(4,8,0)

--- a/src/Data/Binary/Serialise/CBOR/Extra.hs
+++ b/src/Data/Binary/Serialise/CBOR/Extra.hs
@@ -40,6 +40,7 @@ encodeMaybeWith f (Just x) = encodeListLen 1 <> f x
 -- We can assume the record has at least 1 field.
 encodeRecordFields :: [Encoding] -> Encoding
 encodeRecordFields = mconcat
+{-# INLINE encodeRecordFields #-}
 
 -- | Encode an element of a union as single-element map from a field
 -- name to a value.


### PR DESCRIPTION
This changes the generated `Serialise` instances so that `encode` for records avoids a space leak.

Previously for a type like this:

```hs
data JobSpecId
    = JobSpecId
        { _jsi_id         :: !JobId
        , _jsi_input      :: !JSInput
        , _jsi_output     :: !JSOutputStatus
        , _jsi_pipelineId :: !PipelineId
        }
```

we generated code like this:

```hs
encode = \ x ->
    encodeMapLen 4 <>
    encodeRecordFields
       [ encodeString "Id"         <> encode (_jsi_id         x)
       , encodeString "Input"      <> encode (_jsi_input      x)
       , encodeString "Output"     <> encode (_jsi_output     x)
       , encodeString "PipelineId" <> encode (_jsi_pipelineId x)
       ]
```

This binds the record to the variable `x` and uses the record selectors to project out the components. As a consequence, we can end up retaining the entire record until the very end of encoding it. This is a problem if the record is constructed lazily and each component would otherwise have been freed once it was encoded, because we end up realising the whole thing in memory rather than being incremental.

The fix is to pattern-match once on the value to be serialised and bind its components separately:

```hs
encode = \ (JobSpecId _jsi_id _jsi_input _jsi_output _jsi_pipelineId) ->
   encodeMapLen 4 <>
   encodeRecordFields
       [ encodeString "Id"         <> encode _jsi_id
       , encodeString "Input"      <> encode _jsi_input
       , encodeString "Output"     <> encode _jsi_output
       , encodeString "PipelineId" <> encode _jsi_pipelineId
       ]
```

Now the record constructor is garbage once we evaluate the outer pattern-match, and we can free individual fields once they are encoded.

One might hope that the selector thunk optimisation would squash this automatically, but that is somewhat fragile and may not apply at all to large records (see https://gitlab.haskell.org/ghc/ghc/-/issues/20139).
