### PR TITLE
Remove orphan instances for Text and UTCTime

### DIFF
--- a/api-tools.cabal
+++ b/api-tools.cabal
@@ -124,7 +124,7 @@ Library
         -Wall
         -fwarn-tabs
 
-  Default-Language: Haskell2010
+  Default-Language: GHC2021
 
 
 Executable migration-tool
@@ -143,7 +143,7 @@ Executable migration-tool
         -Wall
         -fwarn-tabs
 
-  Default-Language: Haskell2010
+  Default-Language: GHC2021
 
 
 Executable perf-test
@@ -164,7 +164,7 @@ Executable perf-test
         -fwarn-tabs
         -rtsopts
 
-  Default-Language: Haskell2010
+  Default-Language: GHC2021
 
 
 Test-Suite test-api-tools
@@ -205,7 +205,7 @@ Test-Suite test-api-tools
   GHC-Options:
         -Wall
 
-  Default-Language: Haskell2010
+  Default-Language: GHC2021
 
 Benchmark bench-time
   Hs-Source-Dirs:   bench
@@ -224,4 +224,4 @@ Benchmark bench-time
   GHC-Options:
         -Wall
 
-  Default-Language: Haskell2010
+  Default-Language: GHC2021

--- a/api-tools.cabal
+++ b/api-tools.cabal
@@ -96,6 +96,7 @@ Library
         containers           >= 0.5      && < 0.8  ,
         deepseq              >= 1.1      && < 1.6  ,
         lens                 >= 3.8.7    && < 5.4  ,
+        quickcheck-instances                < 0.4  ,
         regex-base           >= 0.93     && < 0.95 ,
         regex-tdfa           >= 1.1.0    && < 1.4  ,
         safe                 >= 0.3.3    && < 0.4  ,

--- a/src/Data/API/Time.hs
+++ b/src/Data/API/Time.hs
@@ -19,6 +19,7 @@ import           Data.Time
 
 import           GHC.Stack
 import           Test.QuickCheck                as QC
+import           Test.QuickCheck.Instances.Time ()
 
 utcFormat :: String
 utcFormat =               "%Y-%m-%dT%H:%M:%SZ"
@@ -136,19 +137,3 @@ unsafeParseDay :: HasCallStack => T.Text -> Day
 unsafeParseDay t = fromMaybe (error msg) (parseDay t)
   where
     msg = "unsafeParseDay: unable to parse: " ++ T.unpack t
-
-
--- TODO: use a more arbitrary instance (quickcheck-instances?)
--- (in particular, there are no subsecond-resolution times here)
-instance QC.Arbitrary UTCTime where
-    arbitrary = QC.oneof
-        [ QC.elements [mk "2010-01-01T00:00:00Z"
-        , mk "2013-05-27T19:13:50Z"
-        , mk "2011-07-20T22:04:00Z"
-        , mk "2012-02-02T15:45:11Z"
-        , mk "2009-11-12T20:57:54Z"
-        , mk "2000-10-28T21:03:24Z"
-        , mk "1965-03-10T09:23:01Z"
-        ]]
-      where
-        mk = unsafeParseUTC

--- a/src/Data/API/Types.hs
+++ b/src/Data/API/Types.hs
@@ -52,6 +52,7 @@ import qualified Data.Text                      as T
 import qualified Data.Text.Encoding             as T
 import qualified Data.ByteString.Char8          as B
 import           Test.QuickCheck                as QC
+import           Test.QuickCheck.Instances.Text ()
 import           Control.Applicative
 import qualified Data.ByteString.Base64         as B64
 import           Language.Haskell.TH
@@ -333,9 +334,6 @@ instance ToJSON Binary where
 
 instance FromJSON Binary where
     parseJSON = withBinary "Binary" return
-
-instance QC.Arbitrary T.Text where
-    arbitrary = T.pack <$> QC.arbitrary
 
 instance QC.Arbitrary Binary where
     arbitrary = Binary <$> B.pack <$> QC.arbitrary


### PR DESCRIPTION
While working on #84, I recalled this one, and it looks like a hopefully non controversial fix.